### PR TITLE
Refactor sheetdata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sheatfish"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "crossterm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sheatfish"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["cadecraft"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Commit the new value to the current cell, or edit the current cell's value if th
 - `[backspace]` -
 Delete the last character of the new value, or clear the current cell if there is no new value
 
+<!-- TODO: cut and paste cells -->
+
 ### Vim Mode
 
 - `[:]` - Exit a file (return to command prompt, ex. `[:][q][enter]` -> quit)
@@ -137,6 +139,8 @@ Delete the last character of the new value, or clear the current cell if there i
 - `[a]` - Append into a cell (add characters at the end)
 
 - `[x]` - Delete the value in the cell
+
+<!-- TODO: cut and paste cells -->
 
 - `[o] [c]` - Insert ("open") a column left of the current selection
 
@@ -178,6 +182,6 @@ Max height of cells to show on screen at once before scrolling (integer from 1..
 Set to 1 to use the Vim Mode keybinds (see above) (integer from 0..=1, default 0)
 
 - `historysize` -
-Max number of prior states stored for the undo history (integer from 0.., default 10)
+Max number of prior states stored for the undo history (integer from 0.., default 100)
 
 <!-- TODO: config option to save files without trailing commas>

--- a/list.csv
+++ b/list.csv
@@ -1,0 +1,8 @@
+test1, 3
+test2, 6
+test3, 9
+test4, 12
+test5, 15
+test6, 18
+test7, 21
+test8, 23

--- a/src/configdata.rs
+++ b/src/configdata.rs
@@ -17,7 +17,7 @@ impl ConfigData {
                 ("vimmode".to_string(), 0),
                 ("viewcellswidth".to_string(), 10),
                 ("viewcellsheight".to_string(), 10),
-                ("historysize".to_string(), 10)
+                ("historysize".to_string(), 100)
             ]),
             savepath: String::from("sheatfish_config.csv")
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,15 +15,13 @@ TODOS:
     - Git ignore editorconfig
     - All commands and features
     - Colors
-    - Modified marker (*) next to filename and warning on quit
-    - Command line arguments to open files?
-    - Zoom features
-    - Rerender after commands like save, delete, etc.
+    - Zoom features (expand and contract cells from one small width to a bigger one?)
+    - Misc. scattered todos
+    - Rerender after ALL commands like save, delete, etc.
     - Refactor the main file
-    - Test: refactored sheet data, so now test it all
     - Performance lag in large window
     - Icon for the app exe
-    - Create a release on GitHub with binaries
+    - Create a release on GitHub with binaries (release build)
 */
 
 /// Main function

--- a/src/render.rs
+++ b/src/render.rs
@@ -33,7 +33,7 @@ pub fn render(config: &mut configdata::ConfigData, data: &sheetdata::SheetData, 
     // Determine sheet bounds
     let viewwidth: usize = config.get_value("viewcellswidth").unwrap_or(10).try_into().unwrap_or(10);
     let viewheight: usize = config.get_value("viewcellsheight").unwrap_or(10).try_into().unwrap_or(10);
-    let selectedcoords = data.selected.unwrap_or((0, 0));
+    let selectedcoords = data.selected().unwrap_or((0, 0));
     let vleft: usize = cmp::max(selectedcoords.1.saturating_sub(viewwidth / 2), 0);
     let vright: usize = cmp::min(vleft + viewwidth, data.bounds().1); // Non-inclusive bound
     let vtop: usize = cmp::max(selectedcoords.0.saturating_sub(viewheight / 2), 0);
@@ -74,7 +74,7 @@ pub fn render(config: &mut configdata::ConfigData, data: &sheetdata::SheetData, 
             let cellval = data.cell((row, col)).unwrap_or("");
             let fmtval = fmt_string_padding(cellval, maxcellwidth.into());
             // Render based on user selection
-            if data.selected.is_some() && (row, col) == data.selected.unwrap() {
+            if data.selected().is_some() && (row, col) == data.selected().unwrap() {
                 printstyl(
                     ((maxcellwidth + 2) as usize * (col + 1 - vleft)).try_into().unwrap_or(0),
                     ((row + 3) - vtop).try_into().unwrap_or(0),
@@ -94,8 +94,8 @@ pub fn render(config: &mut configdata::ConfigData, data: &sheetdata::SheetData, 
 
     printat(0, (vbottom - vtop + 3) as u16, "----", stdout)?;
 
-    if data.selected.is_some() && data.selected_cell_value().is_some() {
-        let selectedstr = format!("({}, {}):", data.selected.unwrap().0, data.selected.unwrap().1);
+    if data.selected().is_some() && data.selected_cell_value().is_some() {
+        let selectedstr = format!("({}, {}):", data.selected().unwrap().0, data.selected().unwrap().1);
         printat(0, (vbottom - vtop + 4) as u16, &selectedstr, stdout)?;
         printat(15, (vbottom - vtop + 4) as u16, &format!("{}", data.selected_cell_value().unwrap()), stdout)?;
     } else {

--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -103,6 +103,7 @@ impl Sheet {
             self.set_selected_coords((0, 0));
             return;
         };
+        // TODO: saturating subtract instead (bounds check in set_selected_coords means vim number commands do nothing if saturating)
         let new0: usize = (selected.0 as isize + delta.0).try_into().unwrap_or(0);
         let new1: usize = (selected.1 as isize + delta.1).try_into().unwrap_or(0);
         self.set_selected_coords((new0, new1));

--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -1,0 +1,248 @@
+use std::cmp;
+
+/// Stores the data for the sheet's cells
+pub struct Sheet {
+    sheet: Vec<Vec<String>>,
+    pub selected: Option<(usize, usize)> // (y, x)
+}
+
+impl Sheet {
+    /// Create a blank default sheet
+    pub fn new() -> Sheet {
+        Sheet {
+            sheet: Vec::new(),
+            selected: Some((0, 0))
+        }
+    }
+    /// Clear the sheet
+    pub fn clear(&mut self) {
+        self.sheet.clear();
+        self.selected = None;
+    }
+    /// Load the sheet from a string and return whether successful
+    pub fn load_string(&mut self, newstring: String) -> bool {
+        // Update the sheet by parsing the string
+        // TODO: comma/quote handling
+        self.clear();
+        let mut bound_width: usize = 0;
+        for resline in newstring.split('\n') {
+            if resline.trim().is_empty() {
+                continue;
+            }
+            self.sheet.push(Vec::new());
+            let sheetn = self.sheet.len();
+            let mut n: usize = 0;
+            for resword in resline.split(',') {
+                self.sheet[sheetn - 1].push(resword.trim().to_string());
+                n += 1;
+            }
+            bound_width = cmp::max(bound_width, n);
+            // Fill in extra lines
+            while n < bound_width {
+                self.sheet[sheetn - 1].push(String::new());
+                n += 1;
+            }
+        }
+        // TODO: test rectangularization
+        // Make the sheet rectangular, if not already, given the longest row
+        for line in &mut self.sheet {
+            while line.len() < bound_width {
+                line.push(String::new());
+            }
+        }
+        // Success
+        true
+    }
+    /// Generate a string from this sheet
+    pub fn generate_string(&mut self) -> String {
+        // Create res by iterating over the sheet
+        let mut res: String = String::new();
+        for row in &self.sheet {
+            let mut first_line = true;
+            for col in row {
+                if first_line {
+                    first_line = false;
+                } else {
+                    res.push(',');
+                    res.push(' ');
+                }
+                res.push_str(col);
+            }
+            res.push('\n');
+        }
+        res
+    }
+    /// Load a vector literal
+    pub fn load_vector(&mut self, newsheet: &Vec<Vec<String>>) {
+        self.clear();
+        self.sheet = newsheet.clone();
+    }
+    /// Get the sheet bounds (y len, x len)
+    /// If the sheet is not rectangular, bounds are based off first row
+    pub fn bounds(&self) -> (usize, usize) {
+        if self.sheet.len() == 0 {
+            return (0, 0);
+        }
+        (self.sheet.len(), self.sheet[0].len())
+    }
+    /// Get whether a point is in bounds (precisely, not rectangularly)
+    pub fn in_bounds(&self, coords: (usize, usize)) -> bool {
+        coords.0 < self.bounds().0 && coords.1 < self.sheet[coords.0].len()
+    }
+    /// Get the value at a point in the sheet
+    pub fn cell(&self, coords: (usize, usize)) -> Option<&str> {
+        if !self.in_bounds(coords) {
+            return None;
+        }
+        Some(&self.sheet[coords.0][coords.1])
+    }
+    /// Move the coordinates of the selected cell
+    pub fn move_selected_coords(&mut self, delta: (isize, isize)) {
+        let Some(selected) = self.selected else {
+            // Default to the start if possible
+            self.set_selected_coords((0, 0));
+            return;
+        };
+        let new0: usize = (selected.0 as isize + delta.0).try_into().unwrap_or(0);
+        let new1: usize = (selected.1 as isize + delta.1).try_into().unwrap_or(0);
+        self.set_selected_coords((new0, new1));
+    }
+    /// Set the coordinates of the selected cell
+    pub fn set_selected_coords(&mut self, coords: (usize, usize)) {
+        if !self.in_bounds(coords) {
+            return;
+        }
+        self.selected = Some(coords);
+    }
+    /// Get the value of the selected cell
+    pub fn selected_cell_value(&self) -> Option<&str> {
+        if self.selected.is_none() {
+            return None;
+        }
+        self.cell(self.selected.unwrap())
+    }
+    /// Set the value of a cell
+    pub fn set_cell_value(&mut self, coords: (usize, usize), newval: String) {
+        if !self.in_bounds(coords) {
+            return;
+        }
+        self.sheet[coords.0][coords.1] = newval;
+    }
+    /// Set the value of the selected cell
+    pub fn set_selected_cell_value(&mut self, newval: String) {
+        if self.selected.is_none() {
+            return;
+        }
+        self.set_cell_value(self.selected.unwrap(), newval);
+    }
+    /// Delete a row at a coordinate
+    pub fn delete_row(&mut self, rowcoord: usize) -> bool {
+        if rowcoord >= self.bounds().0 || self.bounds().0 <= 1 {
+            return false;
+        }
+        self.sheet.remove(rowcoord);
+        if let Some((row, col)) = self.selected {
+            if row >= self.bounds().0 {
+                self.selected = Some((row - 1, col));
+            }
+        }
+        true
+    }
+    /// Delete a column at a coordinate
+    pub fn delete_column(&mut self, colcoord: usize) -> bool {
+        if colcoord >= self.bounds().1 || self.bounds().1 <= 1 {
+            return false;
+        }
+        for row in &mut self.sheet {
+            if colcoord >= row.len() {
+                continue;
+            }
+            row.remove(colcoord);
+        }
+        if let Some((row, col)) = self.selected {
+            if col >= self.bounds().1 {
+                self.selected = Some((row, col - 1));
+            }
+        }
+        true
+    }
+    /// Insert a row at a coordinate
+    pub fn insert_row(&mut self, rowcoord: usize) -> bool {
+        if rowcoord > self.bounds().0 {
+            return false;
+        }
+        self.sheet.insert(rowcoord, vec![String::new(); self.bounds().1]);
+        true
+    }
+    /// Insert a column at a coordinate
+    pub fn insert_column(&mut self, colcoord: usize) -> bool {
+        if colcoord > self.bounds().1 {
+            return false;
+        }
+        for row in &mut self.sheet {
+            if colcoord > row.len() {
+                continue;
+            }
+            row.insert(colcoord, String::new());
+        }
+        true
+    }
+    /// Sort a column at a coordinate
+    pub fn sort_column(&mut self, colcoord: usize) -> bool {
+        self.sort_column_bounded(colcoord, 0, self.bounds().0 - 1)
+    }
+    /// Sort the region of a column from rowstart to rowend, inclusive, by string
+    pub fn sort_column_bounded(&mut self, colcoord: usize, rowstart: usize, rowend: usize) -> bool {
+        // TODO: impl sort range and number-based sort
+        if colcoord >= self.bounds().1 || rowstart > rowend || rowend >= self.bounds().0 {
+            return false;
+        }
+        let mut thisregion: Vec<String> = Vec::new();
+        for row in &mut self.sheet[rowstart..=rowend] {
+            if colcoord >= row.len() {
+                // TODO: err
+                return false; // Cannot sort when not rectangular
+            }
+            thisregion.push(row[colcoord].clone());
+        }
+        thisregion.sort();
+        for (i, row) in &mut self.sheet[rowstart..=rowend].iter_mut().enumerate() {
+            row[colcoord] = thisregion[i].clone();
+        }
+        true
+    }
+    /// Sort the region of a column from rowstart to rowend, inclusive, by number
+    pub fn sort_column_bounded_num(&mut self, colcoord: usize, rowstart: usize, rowend: usize) -> bool {
+        // TODO: impl sort range
+        if colcoord >= self.bounds().1 || rowstart > rowend || rowend >= self.bounds().0 {
+            return false;
+        }
+        let mut thisregion: Vec<(String, f32)> = Vec::new();
+        for row in &mut self.sheet[rowstart..=rowend] {
+            if colcoord >= row.len() {
+                // TODO: err
+                return false; // Cannot sort when not rectangular
+            }
+            thisregion.push((row[colcoord].clone(), row[colcoord].clone().parse::<f32>().unwrap_or(0.0)));
+        }
+        // TODO: fix with sort_by: v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        thisregion.sort_by(|k, j| k.1.partial_cmp(&j.1).unwrap()); // Sort by the f32 (number) component
+        for (i, row) in &mut self.sheet[rowstart..=rowend].iter_mut().enumerate() {
+            row[colcoord] = thisregion[i].0.clone(); // Put the string component
+        }
+        true
+    }
+    /// Make this sheet match another sheet
+    pub fn set_equal(&mut self, other: &Sheet) {
+        self.clear();
+        self.selected = other.selected;
+        self.sheet = other.sheet.clone();
+    }
+    /// Copy this sheet
+    pub fn clone(&self) -> Sheet {
+        // TODO: impl clone and match
+        let mut res: Sheet = Sheet::new();
+        res.set_equal(&self);
+        res
+    }
+}

--- a/src/sheetdata.rs
+++ b/src/sheetdata.rs
@@ -12,7 +12,6 @@ pub struct SheetData {
 }
 
 impl SheetData {
-    // TODO: TEST the refactor (loading files, saving files, undos when cleared, all editing stuff)
     pub fn new() -> SheetData {
         SheetData {
             file_path: "new_file".to_string(),
@@ -55,6 +54,7 @@ impl SheetData {
     }
     /// Undo (move back in history) and return whether successful
     pub fn undo(&mut self) -> bool {
+        self.unsaved = true;
         // Save the current state if needed
         if self.historyframe <= 0 {
             return false;
@@ -72,6 +72,7 @@ impl SheetData {
     }
     /// Redo (move forward in history) and return whether successful
     pub fn redo(&mut self) -> bool {
+        self.unsaved = true;
         if self.historyframe >= 0 && self.historyframe as usize >= self.history.len() - 1 {
             return false;
         }

--- a/src/sheetdata.rs
+++ b/src/sheetdata.rs
@@ -1,25 +1,24 @@
-use std::{ fs, cmp, collections::VecDeque };
+use std::{ fs, collections::VecDeque };
 use crate::configdata::ConfigData;
+use crate::sheet::Sheet;
 
-/// Stores the data for the sheet
+/// Stores the data for managing the sheet's history/file status, and the sheet itself
 pub struct SheetData {
     pub file_path: String,
-    sheet: Vec<Vec<String>>,
-    history: VecDeque<Vec<Vec<String>>>, // Stack of prior sheet states 
+    sheet: Sheet,
+    history: VecDeque<Sheet>, // Stack of prior sheet states 
     historyframe: i32, // The current index of history (if equals history length, then at new frame)
-    pub selected: Option<(usize, usize)>, // (y, x)
     pub unsaved: bool
 }
 
 impl SheetData {
+    // TODO: TEST the refactor (loading files, saving files, undos when cleared, all editing stuff)
     pub fn new() -> SheetData {
-        // TODO: refactor: make this struct for io/stuff, separate from sheet/selected
         SheetData {
             file_path: "new_file".to_string(),
-            sheet: Vec::new(),
+            sheet: Sheet::new(),
             history: VecDeque::new(),
             historyframe: -1,
-            selected: Some((0, 0)),
             unsaved: true
         }
     }
@@ -27,32 +26,12 @@ impl SheetData {
     pub fn dbg_get_history_info(&self) -> (usize, i32) {
         (self.history.len(), self.historyframe)
     }
-    /// Get the sheet bounds (y len, x len)
-    /// If the sheet is not rectangular, bounds are based off first row
-    pub fn bounds(&self) -> (usize, usize) {
-        if self.sheet.len() == 0 {
-            return (0, 0);
-        }
-        (self.sheet.len(), self.sheet[0].len())
-    }
-    /// Get whether a point is in bounds (precisely, not rectangularly)
-    pub fn in_bounds(&self, coords: (usize, usize)) -> bool {
-        coords.0 < self.bounds().0 && coords.1 < self.sheet[coords.0].len()
-    }
-    /// Get the value at a point in the sheet
-    pub fn cell(&self, coords: (usize, usize)) -> Option<&str> {
-        if !self.in_bounds(coords) {
-            return None;
-        }
-        Some(&self.sheet[coords.0][coords.1])
-    }
     /// Clear the sheet state
     /// (reset all history; call this everywhere where the sheet is reset BEFORE resetting it)
     fn clear_sheet_state(&mut self) {
         self.sheet.clear();
         self.history.clear();
         self.unsaved = false;
-        self.selected = None;
         self.historyframe = -1;
     }
     /// Update a sheet state
@@ -86,11 +65,10 @@ impl SheetData {
                 false
             },
             Some(thissheet) => {
-                self.sheet = thissheet.clone();
+                self.sheet.set_equal(&thissheet);
                 true
             }
         }
-        // TODO: impl better: selection out of bounds? (refactor to store selection in the history too? separate struct for "state"?)
     }
     /// Redo (move forward in history) and return whether successful
     pub fn redo(&mut self) -> bool {
@@ -104,13 +82,14 @@ impl SheetData {
                 false
             },
             Some(thissheet) => {
-                self.sheet = thissheet.clone();
+                self.sheet.set_equal(&thissheet);
                 true
             }
         }
     }
     /// Load a file, return whether successful
     pub fn load_file(&mut self, path: &str) -> bool {
+        self.clear_sheet_state();
         self.file_path = path.to_string();
         // Get the file
         let read_res = fs::read_to_string(path);
@@ -118,43 +97,14 @@ impl SheetData {
             return false;
         }
         let res = read_res.unwrap().replace("\r\n", "\n").replace("\r", "\n");
-        // Update the sheet by parsing res
-        // todo: comma/quote handling
-        self.clear_sheet_state(); // TODO: test
-        let mut bound_width: usize = 0;
-        for resline in res.split('\n') {
-            if resline.trim().is_empty() {
-                continue;
-            }
-            self.sheet.push(Vec::new());
-            let sheetn = self.sheet.len();
-            let mut n: usize = 0;
-            for resword in resline.split(',') {
-                self.sheet[sheetn - 1].push(resword.trim().to_string());
-                n += 1;
-            }
-            bound_width = cmp::max(bound_width, n);
-            // Fill in extra lines
-            while n < bound_width {
-                self.sheet[sheetn - 1].push(String::new());
-                n += 1;
-            }
-        }
-        // TODO: test rectangularization
-        // Make the sheet rectangular, if it is not already, given the longest row
-        for line in &mut self.sheet {
-            while line.len() < bound_width {
-                line.push(String::new());
-            }
-        }
-        // Success
-        true
+        // Update the sheet
+        self.sheet.load_string(res)
     }
     /// Load a vector literal
     pub fn load_vector(&mut self, newsheet: &Vec<Vec<String>>) {
+        self.clear_sheet_state();
         self.file_path = "generated_file".to_string();
-        self.clear_sheet_state(); // TODO: test
-        self.sheet = newsheet.clone();
+        self.sheet.load_vector(newsheet);
     }
     /// Save to a file, return whether successful
     pub fn save_file(&mut self, path: &str) -> bool {
@@ -163,21 +113,8 @@ impl SheetData {
             return false; // todo: better error message ("already saved")
         }
         self.file_path = path.to_string();
-        // Create res by iterating over the sheet
-        let mut res: String = String::new();
-        for row in &self.sheet {
-            let mut first_line = true;
-            for col in row {
-                if first_line {
-                    first_line = false;
-                } else {
-                    res.push(',');
-                    res.push(' ');
-                }
-                res.push_str(col);
-            }
-            res.push('\n');
-        }
+        // Generate the string
+        let res: String = self.sheet.generate_string();
         // Open the file
         let write_res = fs::write(path, res);
         if write_res.is_err() {
@@ -187,146 +124,69 @@ impl SheetData {
         self.unsaved = false;
         true
     }
-    /// Move the coordinates of the selected cell
+    /// Get the selected cell in the current sheet
+    pub fn selected(&self) -> Option<(usize, usize)> {
+        self.sheet.selected
+    }
+    /// Call bounds on the current sheet
+    pub fn bounds(&self) -> (usize, usize) {
+        self.sheet.bounds()
+    }
+    pub fn in_bounds(&self, coords: (usize, usize)) -> bool {
+        self.sheet.in_bounds(coords)
+    }
+    pub fn cell(&self, coords: (usize, usize)) -> Option<&str> {
+        self.sheet.cell(coords)
+    }
     pub fn move_selected_coords(&mut self, delta: (isize, isize)) {
-        let Some(selected) = self.selected else {
-            // Default to the start if possible
-            self.set_selected_coords((0, 0));
-            return;
-        };
-        let new0: usize = (selected.0 as isize + delta.0).try_into().unwrap_or(0);
-        let new1: usize = (selected.1 as isize + delta.1).try_into().unwrap_or(0);
-        self.set_selected_coords((new0, new1));
+        self.sheet.move_selected_coords(delta);
     }
-    /// Set the coordinates of the selected cell
     pub fn set_selected_coords(&mut self, coords: (usize, usize)) {
-        if !self.in_bounds(coords) {
-            return;
-        }
-        self.selected = Some(coords);
+        self.sheet.set_selected_coords(coords);
     }
-    /// Get the value of the selected cell
     pub fn selected_cell_value(&self) -> Option<&str> {
-        if self.selected.is_none() {
-            return None;
-        }
-        self.cell(self.selected.unwrap())
+        self.sheet.selected_cell_value()
     }
-    /// Set the value of a cell
     pub fn set_cell_value(&mut self, coords: (usize, usize), newval: String, config: &ConfigData) {
-        if !self.in_bounds(coords) {
-            return;
-        }
-        self.sheet[coords.0][coords.1] = newval;
+        self.sheet.set_cell_value(coords, newval);
         self.update_sheet_state(config);
     }
-    /// Set the value of the selected cell
     pub fn set_selected_cell_value(&mut self, newval: String, config: &ConfigData) {
-        if self.selected.is_none() {
-            return;
-        }
-        self.set_cell_value(self.selected.unwrap(), newval, config);
+        self.sheet.set_selected_cell_value(newval);
+        self.update_sheet_state(config);
     }
-    /// Delete a row at a coordinate
     pub fn delete_row(&mut self, rowcoord: usize, config: &ConfigData) -> bool {
-        if rowcoord >= self.bounds().0 || self.bounds().0 <= 1 {
-            return false;
-        }
-        self.sheet.remove(rowcoord);
-        if let Some((row, col)) = self.selected {
-            if row >= self.bounds().0 {
-                self.selected = Some((row - 1, col));
-            }
-        }
+        self.sheet.delete_row(rowcoord);
         self.update_sheet_state(config);
         true
     }
-    /// Delete a column at a coordinate
     pub fn delete_column(&mut self, colcoord: usize, config: &ConfigData) -> bool {
-        if colcoord >= self.bounds().1 || self.bounds().1 <= 1 {
-            return false;
-        }
-        for row in &mut self.sheet {
-            if colcoord >= row.len() {
-                continue;
-            }
-            row.remove(colcoord);
-        }
-        if let Some((row, col)) = self.selected {
-            if col >= self.bounds().1 {
-                self.selected = Some((row, col - 1));
-            }
-        }
+        self.sheet.delete_column(colcoord);
         self.update_sheet_state(config);
         true
     }
-    /// Insert a row at a coordinate
     pub fn insert_row(&mut self, rowcoord: usize, config: &ConfigData) -> bool {
-        if rowcoord > self.bounds().0 {
-            return false;
-        }
-        self.sheet.insert(rowcoord, vec![String::new(); self.bounds().1]);
+        self.sheet.insert_row(rowcoord);
         self.update_sheet_state(config);
         true
     }
-    /// Insert a column at a coordinate
     pub fn insert_column(&mut self, colcoord: usize, config: &ConfigData) -> bool {
-        if colcoord > self.bounds().1 {
-            return false;
-        }
-        for row in &mut self.sheet {
-            if colcoord > row.len() {
-                continue;
-            }
-            row.insert(colcoord, String::new());
-        }
+        self.sheet.insert_column(colcoord);
         self.update_sheet_state(config);
         true
     }
-    /// Sort a column at a coordinate
     pub fn sort_column(&mut self, colcoord: usize, config: &ConfigData) -> bool {
-        self.sort_column_bounded(colcoord, 0, self.bounds().0 - 1, config)
-    }
-    /// Sort the region of a column from rowstart to rowend, inclusive, by string
-    pub fn sort_column_bounded(&mut self, colcoord: usize, rowstart: usize, rowend: usize, config: &ConfigData) -> bool {
-        // TODO: impl sort range and number-based sort
-        if colcoord >= self.bounds().1 || rowstart > rowend || rowend >= self.bounds().0 {
-            return false;
-        }
-        let mut thisregion: Vec<String> = Vec::new();
-        for row in &mut self.sheet[rowstart..=rowend] {
-            if colcoord >= row.len() {
-                // TODO: err
-                return false; // Cannot sort when not rectangular
-            }
-            thisregion.push(row[colcoord].clone());
-        }
-        thisregion.sort();
-        for (i, row) in &mut self.sheet[rowstart..=rowend].iter_mut().enumerate() {
-            row[colcoord] = thisregion[i].clone();
-        }
+        self.sheet.sort_column(colcoord);
         self.update_sheet_state(config);
         true
     }
-    /// Sort the region of a column from rowstart to rowend, inclusive, by number
+    pub fn sort_column_bounded(&mut self, colcoord: usize, rowstart: usize, rowend: usize, config: &ConfigData) -> bool {
+        self.sheet.sort_column_bounded(colcoord, rowstart, rowend);
+        self.update_sheet_state(config);
+        true
+    }
     pub fn sort_column_bounded_num(&mut self, colcoord: usize, rowstart: usize, rowend: usize, config: &ConfigData) -> bool {
-        // TODO: impl sort range
-        if colcoord >= self.bounds().1 || rowstart > rowend || rowend >= self.bounds().0 {
-            return false;
-        }
-        let mut thisregion: Vec<(String, f32)> = Vec::new();
-        for row in &mut self.sheet[rowstart..=rowend] {
-            if colcoord >= row.len() {
-                // TODO: err
-                return false; // Cannot sort when not rectangular
-            }
-            thisregion.push((row[colcoord].clone(), row[colcoord].clone().parse::<f32>().unwrap_or(0.0)));
-        }
-        // TODO: fix with sort_by: v.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        thisregion.sort_by(|k, j| k.1.partial_cmp(&j.1).unwrap()); // Sort by the f32 (number) component
-        for (i, row) in &mut self.sheet[rowstart..=rowend].iter_mut().enumerate() {
-            row[colcoord] = thisregion[i].0.clone(); // Put the string component
-        }
+        self.sheet.sort_column_bounded_num(colcoord, rowstart, rowend);
         self.update_sheet_state(config);
         true
     }


### PR DESCRIPTION
Move sheet-specific data and functionality (ex. sorting, deleting, getting the value of cells) into the new Sheet struct. SheetData now stores the current sheet as a Sheet and the history as a list of Sheets.
This facilitates various improvements, including moving the cursor to its previous position when undoing actions.